### PR TITLE
作成プログラムをFTPで転送する機能を追加

### DIFF
--- a/app/assets/javascripts/models/source_code.js
+++ b/app/assets/javascripts/models/source_code.js
@@ -62,6 +62,10 @@ Smalruby.SourceCode = Backbone.Model.extend({
     return this.post_('');
   },
 
+  upload: function() {
+    return this.post_('upload');
+  },
+
   write: function(force) {
     if (force == null) {
       force = false;

--- a/app/assets/javascripts/msg/en_us.js
+++ b/app/assets/javascripts/msg/en_us.js
@@ -61,6 +61,9 @@ Blockly.Msg.VIEWS_MAIN_MENU_VIEW_SAVE_BLOCKUI_NOTICE = 'Your program name is "{$
 Blockly.Msg.VIEWS_MAIN_MENU_VIEW_SAVE_ERROR_MESSAGE = "Can't save your program.";
 Blockly.Msg.VIEWS_MAIN_MENU_VIEW_SAVE_CANCELED = 'Canceled to save.';
 Blockly.Msg.VIEWS_MAIN_MENU_VIEW_SAVE_SUCCEEDED = 'Saved.';
+Blockly.Msg.VIEWS_MAIN_MENU_VIEW_UPLOAD_ERROR_MESSAGE = "Can't upload your program.";
+Blockly.Msg.VIEWS_MAIN_MENU_VIEW_UPLOAD_CANCELED = 'Canceled to upload.';
+Blockly.Msg.VIEWS_MAIN_MENU_VIEW_UPLOAD_SUCCEEDED = 'Uploaded.';
 
 Blockly.Msg.VIEWS_MAIN_MENU_VIEW_CHECK_BLOCKUI_TITLE = 'Checking your program';
 Blockly.Msg.VIEWS_MAIN_MENU_VIEW_CHECK_BLOCKUI_MESSAGE = 'Now, checking syntax of your program.';

--- a/app/assets/javascripts/msg/ja.js
+++ b/app/assets/javascripts/msg/ja.js
@@ -64,6 +64,9 @@ Blockly.Msg.VIEWS_MAIN_MENU_VIEW_SAVE_BLOCKUI_NOTICE = 'プログラムの名前
 Blockly.Msg.VIEWS_MAIN_MENU_VIEW_SAVE_ERROR_MESSAGE = 'セーブできませんでした';
 Blockly.Msg.VIEWS_MAIN_MENU_VIEW_SAVE_CANCELED = 'セーブをキャンセルしました';
 Blockly.Msg.VIEWS_MAIN_MENU_VIEW_SAVE_SUCCEEDED = 'セーブしました';
+Blockly.Msg.VIEWS_MAIN_MENU_VIEW_UPLOAD_ERROR_MESSAGE = 'アップロードできませんでした';
+Blockly.Msg.VIEWS_MAIN_MENU_VIEW_UPLOAD_CANCELED = 'アップロードをキャンセルしました';
+Blockly.Msg.VIEWS_MAIN_MENU_VIEW_UPLOAD_SUCCEEDED = 'アップロードしました';
 
 Blockly.Msg.VIEWS_MAIN_MENU_VIEW_CHECK_BLOCKUI_TITLE = 'プログラムのチェック中';
 Blockly.Msg.VIEWS_MAIN_MENU_VIEW_CHECK_BLOCKUI_MESSAGE = 'プログラムの文法をチェックしています。';

--- a/app/assets/javascripts/views/main_menu_view.js.coffee.erb
+++ b/app/assets/javascripts/views/main_menu_view.js.coffee.erb
@@ -14,6 +14,7 @@ Smalruby.MainMenuView = Backbone.View.extend
     'click #download-button': 'onDownload'
     'click #load-local-button': 'onLoadLocal'
     'click #load-button': 'onLoad'
+    'click #upload-button': 'onUpload'
     'click #save-button': 'onSave'
     'click #check-button': 'onCheck'
     'click #reset-button': 'onReset'
@@ -186,6 +187,44 @@ Smalruby.MainMenuView = Backbone.View.extend
     if window.changed
       return unless confirm(<%= bm('.load_confirm') %>)
     $('input#load-file[name="source_code[file]"]').click()
+
+  onUpload: (e) ->
+    e.preventDefault()
+
+    filename = $.trim($('#filename').val())
+    if filename.length <= 0
+      window.errorMessage(<%= bm('.save_error_no_name') %>)
+      $('#filename').focus()
+      return
+
+    sourceCode = @getSourceCode()
+
+    if window.blockMode
+      sourceCode =
+        new Smalruby.SourceCode({ filename: sourceCode.getRbxmlFilename() })
+
+    clearMessages()
+
+    @blockUI
+      title: <%= bm('.save_blockui_title') %>
+      message: <%= bm('.save_blockui_message') %>
+      notice: goog.getMsg(<%= bm('.save_blockui_notice') %>,
+                          { filename: sourceCode.get('filename') })
+
+    sourceCode.save2()
+      .then (data) ->
+        sourceCode.write()
+      .then (data) =>
+        @confirmOverwrite_.call @, data, sourceCode, ->
+          errorMsg = <%= bm('.upload_canceled') %>
+      .then(@unblockUI, @unblockUI)
+      .done ->
+        sourceCode.upload()
+        Smalruby.savedFilename = sourceCode.get('filename')
+        window.changed = false
+        window.successMessage(<%= bm('.upload_succeeded') %>)
+      .fail ->
+        window.errorMessage(<%= bm('.upload_error_message') %>)
 
   onSave: (e) ->
     e.preventDefault()

--- a/app/controllers/source_codes_controller.rb
+++ b/app/controllers/source_codes_controller.rb
@@ -73,8 +73,12 @@ class SourceCodesController < ApplicationController
       filename: filename
     }
 
+    srv  = ENV["FTP_Srv"]
+    user = ENV["FTP_User"]
+    pass = ENV["FTP_Pass"]
+
     begin
-      Net::FTP.open(ENV["FTP_SERVER"], ENV["FTP_CLIENT"], ENV["FTP_PASSWORD"]) do |client|
+      Net::FTP.open(srv, user, pass) do |client|
         client.put(program_path)
       end
     rescue

--- a/app/views/editor/index.html.haml
+++ b/app/views/editor/index.html.haml
@@ -62,6 +62,11 @@
                 %h4
                   %i.icon-folder-open
                   = t('.load')
+            %li
+              %a#upload-button
+                %h4
+                  %i.icon-upload
+                  = t('.upload')
             - if standalone?
               %li
                 %a#save-button

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -13,6 +13,7 @@ en:
       not_ruby_program: " isn't ruby program."
       not_exist: " does not exist."
       exist: " already exist."
+      upload_failed: " is failed to upload."
 
   toolbox_names:
     default: "Normal"
@@ -39,6 +40,7 @@ en:
       msg_input_program_name: "Input your program name(ex:01.rb)"
       menu: "Menu"
       run: "Run"
+      upload: "Upload"
       download: "Download"
       load: "Load"
       save: "Save"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -13,6 +13,7 @@ ja:
       not_ruby_program: "はRubyのプログラムではありません"
       not_exist: "はありません"
       exist: "すでに同じ名前のプログラムがあります"
+      upload_failed: "をアップロードできませんでした"
 
   toolbox_names:
     default: "通常"
@@ -40,6 +41,7 @@ ja:
       msg_input_program_name: "プログラムの名前を入れてね（例：01.rb）"
       menu: "メニュー"
       run: "実行"
+      upload: "アップロード"
       download: "ダウンロード"
       load: "ロード"
       save: "セーブ"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,7 @@ SmalrubyEditor::Application.routes.draw do
   delete 'source_codes/write'
   post 'source_codes/run'
   post 'source_codes/to_blocks'
+  post 'source_codes/upload'
 
   get 'preferences', to: 'users#preferences'
   get 'toolbox', to: 'editor#toolbox'


### PR DESCRIPTION
野口＠リバティ・フィッシュです。

作成したプログラムをFTPでアップロードする機能を追加しました。
FTPでアップロードしたファイルを表示及び、DLできるアプリを別で作る必要があります。